### PR TITLE
[ refactor ] simplify parser type

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ import Text.ILex.FS
 pretty :
      {auto ie : Interpolation e}
   -> {auto ia : Interpolation a}
-  -> Parser1 (BoundedErr e) r s (List a)
+  -> Parser1 (BoundedErr e) (List a)
   -> String
   -> IO ()
 pretty p s =
@@ -113,9 +113,9 @@ tokens we can recognize in a (very basic) CSV
 file. Without further ado, here is our first CSV lexer:
 
 ```idris
-csv0 : L1 q Void 1 CSV0
+csv0 : L1 q Void CSV0
 csv0 =
-  lexer
+  lexer {r = 1}
     [ ctok ',' Comma0
     , nltok '\n' NL0
     , readTok (plus (dot && not ',')) Cell0
@@ -220,9 +220,9 @@ And here's the corresponding lexer:
 linebreak : RExp True
 linebreak = '\n' <|> "\n\r" <|> "\r\n" <|> '\r' <|> '\RS'
 
-csv1 : L1 q Void 1 CSV1
+csv1 : L1 q Void CSV1
 csv1 =
-  lexer
+  lexer {r = 1}
     [ ctok ',' Comma1
     , nltok linebreak NL1
     , ctok "true" (Bool1 True)
@@ -297,9 +297,9 @@ With this, we can enhance our lexer:
 ```idris
 unquote : ByteString -> String
 
-csv1_2 : L1 q Void 1 CSV1
+csv1_2 : L1 q Void CSV1
 csv1_2 =
-  lexer
+  lexer {r = 1}
     [ ctok ',' Comma1
     , nltok linebreak NL1
     , ctok "true" (Bool1 True)
@@ -339,9 +339,9 @@ faster than the above, but I suggest to profile this properly if it
 is used in performance critical code.
 
 ```idris
-lexUQ : L1 q Void 1 String
+lexUQ : L1 q Void String
 lexUQ =
-  lexer
+  lexer {r = 1}
     [ ctok #""""# "\""
     , ctok #""n"# "\n"
     , ctok #""r"# "\r"
@@ -528,7 +528,7 @@ We are going to have a look at the `lchunk` thing when we talk about
 streaming large amounts of data:
 
 ```idris
-csv1_3 : P1 q (BoundedErr Void) QSz QSTCK (List $ Bounded CSV1)
+csv1_3 : P1 q (BoundedErr Void) (List $ Bounded CSV1)
 csv1_3 = P Ini (init [<]) quotedTrans snocChunk quotedErr quotedEOI
 ```
 
@@ -776,7 +776,7 @@ csvEOI st x =
 And here's the final CSV parser:
 
 ```idris
-csv : P1 q (BoundedErr Void) CSz CSTCK Table
+csv : P1 q (BoundedErr Void) Table
 csv = P Ini cinit csvSteps snocChunk csvErr csvEOI
 ```
 

--- a/debug/src/Text/ILex/Debug.idr
+++ b/debug/src/Text/ILex/Debug.idr
@@ -161,16 +161,15 @@ prettyLexer dfa = putPretty dfa
 
 export
 prettyParser :
-     {r : _}
-  -> {default False details : Bool}
-  -> (Index r -> String)
-  -> P1 World e r s a
+     {default False details : Bool}
+  -> (p : P1 World e a)
+  -> (PIx p -> String)
   -> IO ()
-prettyParser shw p = go 0 0
+prettyParser p shw = go 0 0
   where
     go : Nat -> Bits32 -> IO ()
     go tot v =
-      case lt v r of
+      case lt v p.states of
         Just0 prf =>
           let lx := p.lex `at` I v
            in case details of

--- a/examples/src/Examples/Basics.idr
+++ b/examples/src/Examples/Basics.idr
@@ -8,9 +8,9 @@ import Text.ILex
 %hide Data.Linear.(.)
 
 export
-aOrB : L1 q Void 1 AorB
+aOrB : L1 q Void AorB
 aOrB =
-  lexer $ jsonSpaced (Ini {n = 1})
+  lexer {r = 1} $ jsonSpaced (Ini {n = 1})
     [ convTok (plus ('A' <|> 'a')) (const A)
     , convTok (plus ('B' <|> 'b')) (const B)
     ]
@@ -33,9 +33,9 @@ identifier : RExp True
 identifier = plus $ alphaNum <|> '_'
 
 export
-ident : L1 q Void 1 Ident
+ident : L1 q Void Ident
 ident =
-  lexer $ jsonSpaced (Ini {n = 1})
+  lexer {r = 1} $ jsonSpaced (Ini {n = 1})
     [ ctok "else" Else
     , readTok identifier Id
     ]

--- a/json/src/JSON/Parser.idr
+++ b/json/src/JSON/Parser.idr
@@ -279,7 +279,7 @@ jsonEOI sk s t =
       _    # t => Right JNull # t
 
 export
-json : P1 q (BoundedErr Void) JSz SK JSON
+json : P1 q (BoundedErr Void) JSON
 json = P JIni (init PI) jsonTrans (\x => (Nothing #)) jsonErr jsonEOI
 
 export %inline
@@ -319,7 +319,7 @@ arrEOI st sk t =
 ||| A parser that is capable of streaming a single large
 ||| array of JSON values.
 export
-jsonArray : P1 q (BoundedErr Void) JSz SK (List JSON)
+jsonArray : P1 q (BoundedErr Void) (List JSON)
 jsonArray = P JIni (init PI) jsonTrans arrChunk jsonErr arrEOI
 
 ||| Parser that is capable of streaming large amounts of
@@ -328,5 +328,5 @@ jsonArray = P JIni (init PI) jsonTrans arrChunk jsonErr arrEOI
 ||| Values need not be separated by whitespace but the longest
 ||| possible value will always be consumed.
 export
-jsonValues : P1 q (BoundedErr Void) JSz SK (List JSON)
+jsonValues : P1 q (BoundedErr Void) (List JSON)
 jsonValues = P JIni (init $ PV [<]) jsonTrans arrChunk jsonErr arrEOI

--- a/json/src/JSON/Parser.idr
+++ b/json/src/JSON/Parser.idr
@@ -278,7 +278,7 @@ jsonEOI sk s t =
       PF v # t => Right v # t
       _    # t => Right JNull # t
 
-export
+public export
 json : P1 q (BoundedErr Void) JSON
 json = P JIni (init PI) jsonTrans (\x => (Nothing #)) jsonErr jsonEOI
 
@@ -318,7 +318,7 @@ arrEOI st sk t =
 
 ||| A parser that is capable of streaming a single large
 ||| array of JSON values.
-export
+public export
 jsonArray : P1 q (BoundedErr Void) (List JSON)
 jsonArray = P JIni (init PI) jsonTrans arrChunk jsonErr arrEOI
 
@@ -327,6 +327,6 @@ jsonArray = P JIni (init PI) jsonTrans arrChunk jsonErr arrEOI
 |||
 ||| Values need not be separated by whitespace but the longest
 ||| possible value will always be consumed.
-export
+public export
 jsonValues : P1 q (BoundedErr Void) (List JSON)
 jsonValues = P JIni (init $ PV [<]) jsonTrans arrChunk jsonErr arrEOI

--- a/profile/src/DJSON.idr
+++ b/profile/src/DJSON.idr
@@ -172,8 +172,8 @@ jsonEOI st sk =
     JVal:>v::_ => pure (Right v)
     _          => arrFail DSK jsonErr st sk
 
-export
-djson : P1 q (BoundedErr Void) DSz DSK JSON
+public export
+djson : P1 q (BoundedErr Void) JSON
 djson = P (cast JInit) (init $ JInit:>[]) jsonTrans (\x => (Nothing #)) jsonErr jsonEOI
 
 export %inline

--- a/src/Text/ILex/Parser.idr
+++ b/src/Text/ILex/Parser.idr
@@ -78,15 +78,39 @@ Lex1 q r s = Arr32 r (DFA q r s)
 ||| lexicographic token determines the next automaton
 ||| state plus lexer to use.
 public export
-record P1 (q,e : Type) (r : Bits32) (s : Type -> Type) (a : Type) where
+record P1 (q,e : Type) (a : Type) where
   constructor P
-  init  : Index r
-  stck  : F1 q (s q)
-  lex   : Lex1 q r s
-  chunk : s q -> F1 q (Maybe a)
-  err   : Arr32 r (s q -> F1 q e)
-  eoi   : Index r -> s q -> F1 q (Either e a)
-  {auto hasb : HasBytes s}
+  0 states : Bits32
+  0 state  : Type -> Type
+  init   : Index states
+  stck   : F1 q (state q)
+  lex    : Lex1 q states state
+  chunk  : state q -> F1 q (Maybe a)
+  err    : Arr32 states (state q -> F1 q e)
+  eoi    : Index states -> state q -> F1 q (Either e a)
+  {auto hasb : HasBytes state}
+
+public export
+0 PST : (p : P1 q e a) -> Type
+PST p = p.state q
+
+public export
+0 PIx : (p : P1 q e a) -> Type
+PIx p = Index p.states
+
+public export
+0 PStep : (p : P1 q e a) -> Type
+PStep p = Step1 q p.states p.state
+
+||| An array of arrays describing a lexer's state machine.
+public export
+0 PByteStep : Nat -> (p : P1 q e a) -> Type
+PByteStep n p = IArray 256 (Transition n q p.states p.state)
+
+||| An array of arrays describing a lexer's state machine.
+public export
+0 PStepper : Nat -> (p : P1 q e a) -> Type
+PStepper n p = IArray (S n) (PByteStep n p)
 
 export
 arrFail :
@@ -101,19 +125,19 @@ arrFail s arr ix st t =
   in Left err # t
 
 export %inline
-fail : P1 q e r s a -> Index r -> s q -> F1 q (Either e x)
-fail = arrFail s . err
+fail : (p : P1 q e a) -> PIx p -> PST p -> F1 q (Either e x)
+fail p = arrFail p.state $ p.err
 
 export
-lastStep : P1 q e r s a -> Step1 q r s -> Index r -> s q -> F1 q (Either e a)
+lastStep : (p : P1 q e a) -> PStep p -> PIx p -> PST p -> F1 q (Either e a)
 lastStep p f st stck t =
   let r # t := f (stck # t)
       _ # t := write1 (bytes @{p.hasb} stck) "" t
    in p.eoi r stck t
 
 public export
-0 Parser1 : (e : Type) -> (r : Bits32) -> (s : Type -> Type) -> (a : Type) -> Type
-Parser1 e r s a = {0 q : _} -> P1 q e r s a
+0 Parser1 : (e : Type) -> (a : Type) -> Type
+Parser1 e a = {0 q : _} -> P1 q e a
 
 export %inline
 lex1 : {r : _} -> List (Entry r (DFA q r s)) -> Lex1 q r s

--- a/src/Text/ILex/Parser.idr
+++ b/src/Text/ILex/Parser.idr
@@ -80,7 +80,7 @@ Lex1 q r s = Arr32 r (DFA q r s)
 public export
 record P1 (q,e : Type) (a : Type) where
   constructor P
-  {0 states  : Bits32}
+  {states    : Bits32}
   {0 state   : Type -> Type}
   init       : Index states
   stck       : F1 q (state q)

--- a/src/Text/ILex/Parser.idr
+++ b/src/Text/ILex/Parser.idr
@@ -80,14 +80,14 @@ Lex1 q r s = Arr32 r (DFA q r s)
 public export
 record P1 (q,e : Type) (a : Type) where
   constructor P
-  0 states : Bits32
-  0 state  : Type -> Type
-  init   : Index states
-  stck   : F1 q (state q)
-  lex    : Lex1 q states state
-  chunk  : state q -> F1 q (Maybe a)
-  err    : Arr32 states (state q -> F1 q e)
-  eoi    : Index states -> state q -> F1 q (Either e a)
+  {0 states  : Bits32}
+  {0 state   : Type -> Type}
+  init       : Index states
+  stck       : F1 q (state q)
+  lex        : Lex1 q states state
+  chunk      : state q -> F1 q (Maybe a)
+  err        : Arr32 states (state q -> F1 q e)
+  eoi        : Index states -> state q -> F1 q (Either e a)
   {auto hasb : HasBytes state}
 
 public export

--- a/src/Text/ILex/Runner.idr
+++ b/src/Text/ILex/Runner.idr
@@ -10,7 +10,7 @@ import public Text.ILex.Parser
 
 runFrom :
      {n      : Nat}
-  -> (l      : Parser1 e r s a)
+  -> (l      : Parser1 e a)
   -> (pos    : Nat)
   -> {auto x : Ix pos n}
   -> IBuffer n
@@ -18,17 +18,17 @@ runFrom :
 
 ||| Tries to parse a byte vector into a value.
 export %inline
-run : {n : _} -> Parser1 e r s a -> IBuffer n -> Either e a
+run : {n : _} -> Parser1 e a -> IBuffer n -> Either e a
 run l buf = runFrom l n buf
 
 ||| Like `run` but processes a UTF-8 string instead.
 export %inline
-runString : Parser1 e r s a -> String -> Either e a
+runString : Parser1 e a -> String -> Either e a
 runString l s = run l (fromString s)
 
 ||| Like `run` but processes a `ByteString` instead.
 export
-runBytes : Parser1 e r s a -> ByteString -> Either e a
+runBytes : Parser1 e a -> ByteString -> Either e a
 runBytes l (BS s $ BV buf off lte) =
   runFrom l s {x = offsetToIx off} (take (off+s) buf)
 
@@ -38,7 +38,7 @@ runBytes l (BS s $ BV buf off lte) =
 export %inline
 parse :
      {n : _}
-  -> Parser1 (BoundedErr e) r s a
+  -> Parser1 (BoundedErr e) a
   -> Origin
   -> IBuffer n
   -> Either (ParseError e) a
@@ -47,7 +47,7 @@ parse l o buf = mapFst (toParseError o (toString buf 0 n)) (run l buf)
 ||| Like `parse` but processes a UTF-8 string instead.
 export %inline
 parseString :
-     Parser1 (BoundedErr e) r s a
+     Parser1 (BoundedErr e) a
   -> Origin
   -> String
   -> Either (ParseError e) a
@@ -56,7 +56,7 @@ parseString l o s = parse l o (fromString s)
 ||| Like `parse` but processes a `ByteString` instead.
 export %inline
 parseBytes :
-     Parser1 (BoundedErr e) r s a
+     Parser1 (BoundedErr e) a
   -> Origin
   -> ByteString
   -> Either (ParseError e) a
@@ -66,19 +66,17 @@ parseBytes l o bs = mapFst (toParseError o (toString bs)) (runBytes l bs)
 -- Lexer run loop
 --------------------------------------------------------------------------------
 
-parameters {0 s     : Type -> Type}
-           {0 r     : Bits32}
-           {0 q,e,a : Type}
+parameters {0 q,e,a : Type}
            {0 n     : Nat}
-           (stck    : s q)
-           (parser  : P1 q e r s a)
+           (parser  : P1 q e a)
+           (stck    : PST parser)
            (buf     : IBuffer n)
            (bytes   : Ref q ByteString)
 
   step :
-       (st          : Index r)
-    -> (dfa         : Stepper k q r s)
-    -> (cur         : ByteStep k q r s)
+       (st          : PIx parser)
+    -> (dfa         : PStepper k parser)
+    -> (cur         : PByteStep k parser)
     -> (from        : Ix m n)
     -> (pos         : Nat)
     -> {auto x      : Ix pos n}
@@ -86,17 +84,17 @@ parameters {0 s     : Type -> Type}
     -> F1 q (Either e a)
 
   succ :
-       (st          : Index r)
-    -> (dfa         : Stepper k q r s)
-    -> (cur         : ByteStep k q r s)
-    -> (last        : Step1 q r s)
+       (st          : PIx parser)
+    -> (dfa         : PStepper k parser)
+    -> (cur         : PByteStep k parser)
+    -> (last        : PStep parser)
     -> (from        : Ix m n)
     -> (pos         : Nat)
     -> {auto x      : Ix pos n}
     -> {auto 0 lte2 : LTE (ixToNat from) (ixToNat x)}
     -> F1 q (Either e a)
 
-  loop : (st : Index r) -> (pos : Nat) -> (x : Ix pos n) => F1 q (Either e a)
+  loop : (st : PIx parser) -> (pos : Nat) -> (x : Ix pos n) => F1 q (Either e a)
   loop st 0     t =
    let _ # t := write1 bytes "" t
     in parser.eoi st stck t
@@ -154,7 +152,7 @@ parameters {0 s     : Type -> Type}
 
 runFrom p pos buf = run1 (go p)
   where
-    go : P1 q e r s a -> F1 q (Either e a)
+    go : P1 q e a -> F1 q (Either e a)
     go p t =
      let x # t := stck p t
-      in loop x p buf (bytes @{p.hasb} x) p.init pos t
+      in loop p x buf (bytes @{p.hasb} x) p.init pos t

--- a/src/Text/ILex/Stack.idr
+++ b/src/Text/ILex/Stack.idr
@@ -150,7 +150,7 @@ value mv m =
  let iniSteps  := E VIni $ dfa (map toStep m)
      doneSteps := E VDone $ dfa (mapMaybe ignore m)
      states    := lex1 [iniSteps, doneSteps]
-  in P _ _ VIni (init mv) states noChunk (errs []) valEOI
+  in P VIni (init mv) states noChunk (errs []) valEOI
 
 --------------------------------------------------------------------------------
 -- Lexer
@@ -232,4 +232,4 @@ lexer :
   -> Steps q r (Stack e (SnocList $ Bounded a) r)
   -> L1 q e a
 lexer m =
-  P _ _ Ini (init [<]) (lex1 [E Ini $ dfa m]) snocChunk (errs []) lexEOI
+  P Ini (init [<]) (lex1 [E Ini $ dfa m]) snocChunk (errs []) lexEOI

--- a/src/Text/ILex/Stack.idr
+++ b/src/Text/ILex/Stack.idr
@@ -141,7 +141,7 @@ valEOI i sk =
 
 public export
 0 PVal1 : (q,e : Type) -> (a : Type) -> Type
-PVal1 q e a = P1 q (BoundedErr e) VSz (Stack e (Maybe a) VSz) a
+PVal1 q e a = P1 q (BoundedErr e) a
 
 ||| Parser for simple values based on regular expressions.
 export
@@ -150,7 +150,7 @@ value mv m =
  let iniSteps  := E VIni $ dfa (map toStep m)
      doneSteps := E VDone $ dfa (mapMaybe ignore m)
      states    := lex1 [iniSteps, doneSteps]
-  in P VIni (init mv) states noChunk (errs []) valEOI
+  in P _ _ VIni (init mv) states noChunk (errs []) valEOI
 
 --------------------------------------------------------------------------------
 -- Lexer
@@ -218,24 +218,18 @@ lexEOI i sk =
      else unexpected [] sk >>= pure . Left
 
 public export
-0 L1 : (q,e : Type) -> Bits32 -> (a : Type) -> Type
-L1 q e r a =
-  P1
-    q
-    (BoundedErr e)
-    r
-    (Stack e (SnocList $ Bounded a) r)
-    (List $ Bounded a)
+0 L1 : (q,e : Type) -> (a : Type) -> Type
+L1 q e a = P1 q (BoundedErr e) (List $ Bounded a)
 
 public export
-0 Lexer : (e : Type) -> Bits32 -> Type -> Type
-Lexer e r a = {0 q : Type} -> L1 q e r a
+0 Lexer : (e : Type) -> Type -> Type
+Lexer e a = {0 q : Type} -> L1 q e a
 
 export
 lexer :
      {r : _}
   -> {auto 0 lt  : 0 < r}
   -> Steps q r (Stack e (SnocList $ Bounded a) r)
-  -> L1 q e r a
+  -> L1 q e a
 lexer m =
-  P Ini (init [<]) (lex1 [E Ini $ dfa m]) snocChunk (errs []) lexEOI
+  P _ _ Ini (init [<]) (lex1 [E Ini $ dfa m]) snocChunk (errs []) lexEOI

--- a/streams/src/Text/ILex/FS.idr
+++ b/streams/src/Text/ILex/FS.idr
@@ -9,12 +9,12 @@ import Text.ILex.Runner1
 
 %default total
 
-parameters (p : P1 q e r s a)
+parameters (p : P1 q e a)
 
   ||| Tries to read the last token of an input stream and
   ||| append it to the already accumulated list of tokens.
   export
-  appLast : Index r -> s q -> Maybe (Step1 q r s) -> F1 q (Either e a)
+  appLast : PIx p -> PST p -> Maybe (PStep p) -> F1 q (Either e a)
   appLast st sk tok =
     read1 (bytes @{p.hasb} sk) >>= \case
       BS 0 _ => p.eoi st sk
@@ -33,16 +33,15 @@ export
 streamParse :
      {auto has : Has (ParseError e) es}
   -> {auto lft : ELift1 q f}
-  -> {auto hap : HasPosition s}
-  -> {auto hab : HasBytes s}
-  -> P1 q (BoundedErr e) r s a
+  -> (prs      : P1 q (BoundedErr e) a)
+  -> {auto hap : HasPosition prs.state}
   -> Origin
   -> Pull f ByteString es x
   -> Pull f a es x
 streamParse prs o pl = Prelude.do
   st      <- lift1 (init prs)
-  posprev <- lift1 (getPosition @{st.stack})
-  prev    <- readref (bytes st.stack)
+  posprev <- lift1 {s = q} (getPosition @{st.stack} @{hap})
+  prev    <- readref {s = q} (bytes @{prs.hasb} st.stack)
   go prev posprev empty st pl
 
   where
@@ -66,18 +65,18 @@ streamParse prs o pl = Prelude.do
          (prev0    : ByteString)
       -> (posprev0 : Position)
       -> (bs0      : ByteString)
-      -> LexState q (BoundedErr e) r s
+      -> LexState prs
       -> Pull f ByteString es x
       -> Pull f a es x
     go prev0 posprev0 bs0 st p =
       assert_total $ P.uncons p >>= \case
         Left res      =>
-          lift1 (appLast prs st.state st.stack st.tok) >>= \case
+          lift1 {s = q} (appLast prs st.state st.stack st.tok) >>= \case
             Left x  => throw (toErr prev0 posprev0 bs0 x)
             Right v => emit v $> res
         Right (bs1,p2) => Prelude.do
-          posprev1 <- lift1 (getPosition @{st.stack})
-          prev1    <- readref (bytes st.stack)
+          posprev1 <- lift1 {s = q} (getPosition @{st.stack} @{hap})
+          prev1    <- readref {s = q} (bytes @{prs.hasb} st.stack)
           lift1 (pparseBytes prs st bs1) >>= \case
             Left x        => throw (toErr prev0 posprev0 (bs0 <+> bs1) x)
             Right (st2,m) => consMaybe m (go prev1 posprev1 bs1 st2 p2)
@@ -86,10 +85,10 @@ export %inline
 streamVal :
      {auto has : Has (ParseError e) es}
   -> {auto lft : ELift1 q f}
-  -> {auto hap : HasPosition s}
-  -> {auto hab : HasBytes s}
   -> (dflts : Lazy a)
-  -> P1 q (BoundedErr e) r s a
+  -> (prs : P1 q (BoundedErr e) a)
+  -> {auto hap : HasPosition prs.state}
+  -> {auto hab : HasBytes prs.state}
   -> Origin
   -> Stream f es ByteString
   -> Pull f o es a

--- a/streams/src/Text/ILex/Runner1.idr
+++ b/streams/src/Text/ILex/Runner1.idr
@@ -11,17 +11,17 @@ import Text.ILex.Internal.Runner
 ||| the remainder of the previous chunk that marks
 ||| the beginning of the current token.
 public export
-record LexState (q,e : Type) (r : Bits32) (s : Type -> Type) where
+record LexState (p : P1 q e a) where
   constructor LST
   {0 sts  : Nat}
-  state   : Index r
-  stack   : s q
-  dfa     : Stepper sts q r s
-  cur     : ByteStep sts q r s
-  tok     : Maybe (Step1 q r s)
+  state   : PIx p
+  stack   : PST p
+  dfa     : PStepper sts p
+  cur     : PByteStep sts p
+  tok     : Maybe (PStep p)
 
 export
-init : P1 q e r s a -> F1 q (LexState q e r s)
+init : (p : P1 q e a) -> F1 q (LexState p)
 init p t =
  let stck # t := p.stck t
      L _ dfa  := p.lex `at` p.init
@@ -31,20 +31,20 @@ init p t =
 ||| till the end of a chunk of bytes, allowing for a remainder of
 ||| bytes that could not yet be identified as a tokens.
 public export
-0 PartRes : (q,e : Type) -> (r : Bits32) -> (s : Type -> Type) -> (a : Type) -> Type
-PartRes q e r s a = F1 q (Either e (LexState q e r s, Maybe a))
+0 PartRes : (p : P1 q e a) -> Type
+PartRes p = F1 q (Either e (LexState p, Maybe a))
 
 export
 pparseFrom :
-     (p      : P1 q e r s a)
-  -> (st     : LexState q e r s)
+     (p      : P1 q e a)
+  -> (st     : LexState p)
   -> (pos    : Nat)
   -> {auto x : Ix pos n}
   -> IBuffer n
-  -> PartRes q e r s a
+  -> PartRes p
 
 export
-pparseBytes : P1 q e r s a -> LexState q e r s -> ByteString -> PartRes q e r s a
+pparseBytes : (p : P1 q e a) -> LexState p -> ByteString -> PartRes p
 pparseBytes p st (BS s $ BV buf off lte) =
   pparseFrom p st s {x = offsetToIx off} (take (off+s) buf)
 
@@ -52,44 +52,42 @@ pparseBytes p st (BS s $ BV buf off lte) =
 -- Partial run loop
 --------------------------------------------------------------------------------
 
-parameters {0 s     : Type -> Type}
-           {0 r     : Bits32}
-           {0 q,e,a : Type}
+parameters {0 q,e,a : Type}
            {0 n     : Nat}
-           (stck    : s q)
-           (parser  : P1 q e r s a)
+           (parser  : P1 q e a)
+           (stck    : PST parser)
            (buf     : IBuffer n)
            (bytes   : Ref q ByteString)
 
   pstep :
-       (st          : Index r)
-    -> (dfa         : Stepper k q r s)            -- current finite automaton
-    -> (cur         : ByteStep k q r s)           -- current automaton state
+       (st          : PIx parser)
+    -> (dfa         : PStepper k parser)          -- current finite automaton
+    -> (cur         : PByteStep k parser)         -- current automaton state
     -> (prev        : ByteString)
     -> (from        : Ix m n)                     -- start of current token
     -> (pos         : Nat)                        -- reverse position in the byte array
     -> {auto x      : Ix pos n}                   -- position in the byte array
     -> {auto 0 lte2 : LTE (ixToNat from) (ixToNat x)}
-    -> PartRes q e r s a
+    -> PartRes parser
 
   psucc :
-       (st          : Index r)
-    -> (dfa         : Stepper k q r s)            -- current finite automaton
-    -> (cur         : ByteStep k q r s)           -- current automaton state
+       (st          : PIx parser)
+    -> (dfa         : PStepper k parser)          -- current finite automaton
+    -> (cur         : PByteStep k parser)         -- current automaton state
     -> (prev        : ByteString)
-    -> (last        : Step1 q r s)                -- last encountered terminal state
+    -> (last        : PStep parser)               -- last encountered terminal state
     -> (from        : Ix m n)                     -- start of current token
     -> (pos         : Nat)                        -- reverse position in the byte array
     -> {auto x      : Ix pos n}                   -- position in the byte array
     -> {auto 0 lte2 : LTE (ixToNat from) (ixToNat x)}
-    -> PartRes q e r s a
+    -> PartRes parser
 
   -- Accumulates lexemes by applying the maximum munch strategy:
   -- The largest matched lexeme is consumed and kept.
   -- This consumes at least one byte for the next token and
   -- immediately aborts with an error in case the current
   -- byte leads to the zero state.
-  ploop : Index r -> (pos : Nat) -> (x : Ix pos n) => PartRes q e r s a
+  ploop : PIx parser -> (pos : Nat) -> (x : Ix pos n) => PartRes parser
   ploop st 0     t =
    let mv  # t := P1.chunk parser stck t
        L _ dfa := parser.lex `at` st
@@ -158,15 +156,15 @@ pparseFrom p lst@(LST st sk dfa cur tok) pos buf t =
          prev # t := read1 bytes t
       in case cur `atByte` byte of
            Keep         => case tok of
-             Just f  => psucc sk p buf bytes st dfa cur prev f x k t
-             Nothing => pstep sk p buf bytes st dfa cur prev   x k t
-           Done   f     => let s2 # t := f (sk # t) in ploop sk p buf bytes s2 k t
+             Just f  => psucc p sk buf bytes st dfa cur prev f x k t
+             Nothing => pstep p sk buf bytes st dfa cur prev   x k t
+           Done   f     => let s2 # t := f (sk # t) in ploop p sk buf bytes s2 k t
            DoneBS f     =>
             let _  # t := writeBSP prev buf x k bytes t
                 s2 # t := f (sk # t)
-             in ploop sk p buf bytes s2 k t
-           Move   nxt f => psucc sk p buf bytes st dfa (dfa `at` nxt) prev f x k t
-           MoveE  nxt   => pstep sk p buf bytes st dfa (dfa `at` nxt) prev   x k t
+             in ploop p sk buf bytes s2 k t
+           Move   nxt f => psucc p sk buf bytes st dfa (dfa `at` nxt) prev f x k t
+           MoveE  nxt   => pstep p sk buf bytes st dfa (dfa `at` nxt) prev   x k t
            Bottom     => case tok of
-             Just f  => let s2 # t := f (sk # t) in ploop sk p buf bytes s2 (S k) t
+             Just f  => let s2 # t := f (sk # t) in ploop p sk buf bytes s2 (S k) t
              Nothing => fail p st sk t

--- a/test/src/Context.idr
+++ b/test/src/Context.idr
@@ -76,7 +76,7 @@ leoi sk s =
 
 export
 lit : P1 q (BoundedErr Void) (List $ Bounded Lit)
-lit = P _ _ SLit (init [<]) lit1 (\x => (Nothing #)) litErr leoi
+lit = P SLit (init [<]) lit1 (\x => (Nothing #)) litErr leoi
 
 space : Nat -> Gen String
 space n =  string (linear 0 5) (element [' ', '\t', '\r', '\t'])

--- a/test/src/Context.idr
+++ b/test/src/Context.idr
@@ -75,8 +75,8 @@ leoi sk s =
     True  => replace1 s.stack_ [<] >>= pure . Right . (<>> [])
 
 export
-lit : P1 q (BoundedErr Void) 2 SK (List $ Bounded Lit)
-lit = P SLit (init [<]) lit1 (\x => (Nothing #)) litErr leoi
+lit : P1 q (BoundedErr Void) (List $ Bounded Lit)
+lit = P _ _ SLit (init [<]) lit1 (\x => (Nothing #)) litErr leoi
 
 space : Nat -> Gen String
 space n =  string (linear 0 5) (element [' ', '\t', '\r', '\t'])

--- a/test/src/Repeat.idr
+++ b/test/src/Repeat.idr
@@ -21,9 +21,9 @@ data ABC : Type where
 export
 Interpolation ABC where interpolate = show
 
-abc : L1 q Void 1 ABC
+abc : L1 q Void ABC
 abc =
-  lexer $ jsonSpaced (Ini {n = 1})
+  lexer {r = 1} $ jsonSpaced (Ini {n = 1})
     [ readTok ('A' >> repeat  4 'a') (const A)
     , readTok ('B' >> atmost  3 'b') (const B)
     , readTok ('C' >> atleast 3 'c') (const C)

--- a/test/src/Runner.idr
+++ b/test/src/Runner.idr
@@ -25,9 +25,9 @@ data Val : Type where
 export
 Interpolation Val where interpolate = show
 
-val : L1 q Void 1 Val
+val : L1 q Void Val
 val =
-  lexer $ jsonSpaced (Ini {n = 1})
+  lexer {r = 1} $ jsonSpaced (Ini {n = 1})
     [ convTok ('A' >> plus 'a') (const MA)
     , ctok 'A' A
     , convTok (plus $ charLike 'B') (const B)
@@ -67,16 +67,16 @@ vals : Gen (Val, String)
 vals = choice [genA, genMA, genB, genC]
 
 export
-lexBounds : Parser1 (BoundedErr e) r s a -> String -> Either (ParseError e) a
+lexBounds : Parser1 (BoundedErr e) a -> String -> Either (ParseError e) a
 lexBounds lex = parseString lex Virtual
 
 export
-lexBytes : Parser1 (BoundedErr e) r s a -> ByteString -> Either (ParseError e) a
+lexBytes : Parser1 (BoundedErr e) a -> ByteString -> Either (ParseError e) a
 lexBytes lex = parseBytes lex Virtual
 
 export
 lexNoBounds :
-     Parser1 (BoundedErr e) r s (List $ Bounded a)
+     Parser1 (BoundedErr e) (List $ Bounded a)
   -> String
   -> Either (ParseError e) (List a)
 lexNoBounds lex = map (map val) . lexBounds lex

--- a/test/src/Unicode.idr
+++ b/test/src/Unicode.idr
@@ -43,9 +43,9 @@ data Cat : Type where
 
 %runElab derive "Cat" [Show,Eq]
 
-cat : L1 q Void 1 Cat
+cat : L1 q Void Cat
 cat =
-  lexer
+  lexer {r = 1}
     [ readTok U.unassigned Cn
     , readTok U.uppercaseLetter Lu
     , readTok U.lowercaseLetter Ll

--- a/toml/src/Text/TOML/Parser.idr
+++ b/toml/src/Text/TOML/Parser.idr
@@ -291,6 +291,6 @@ tomlEOI st sk =
     False => arrFail TSTCK tomlErr st sk
     True  => getStack >>= pure . toTable
 
-export
-toml : P1 q TErr TSz TSTCK TomlTable
+public export
+toml : P1 q TErr TomlTable
 toml = P TIni (init empty) tomlTrans (\x => (Nothing #)) tomlErr tomlEOI


### PR DESCRIPTION
This simplifies externally visible parser types at the cost of breaking all downstream libs.