### PR TITLE
[ refactor ] use SnocList for parser stack

### DIFF
--- a/profile/src/DJSON.idr
+++ b/profile/src/DJSON.idr
@@ -12,22 +12,22 @@ import Syntax.T1
 %hide JSON.Parser.JStr
 %language ElabReflection
 
-data JState : List Type -> Type where
-  JInit : JState []
-  JVal  : JState [JSON]
+data JState : SnocList Type -> Type where
+  JInit : JState [<]
+  JVal  : JState [<JSON]
 
-  JArr  : JState [SnocList JSON]
-  JArrV : JState [Void]
-  JArrS : JState [Void]
+  JArr  : JState [<SnocList JSON]
+  JArrV : JState [<Void]
+  JArrS : JState [<Void]
 
-  JObj  : JState [SnocList (String,JSON)]
-  JObjL : JState [String,SnocList (String,JSON)]
-  JObjC : JState [Void]
-  JObjV : JState [Void]
-  JObjS : JState [Void]
+  JObj  : JState [<SnocList (String,JSON)]
+  JObjL : JState [<SnocList (String,JSON),String]
+  JObjC : JState [<Void]
+  JObjV : JState [<Void]
+  JObjS : JState [<Void]
 
-  JStr  : JState [Void]
-  JErr  : JState []
+  JStr  : JState [<Void]
+  JErr  : JState [<]
 
 %runElab deriveIndexed "JState" [Show,ConIndex]
 
@@ -52,29 +52,29 @@ parameters {auto sk : DSK q}
 
   %inline
   jval : JSON -> StateAct q JState DSz
-  jval v JArr  (sv::xs)    = putStackAsC (JArr:>(sv:<v)::xs) JArrV
-  jval v JObjL (l::sv::xs) = putStackAsC (JObj:>(sv:<(l,v))::xs) JObjV
-  jval v JInit x           = dput JVal (v::x)
-  jval _ s     x           = derr JErr s x
+  jval v JArr  (sx:<sv)    = putStackAsC (sx:<(sv:<v):>JArr) JArrV
+  jval v JObjL (sx:<sv:<l) = putStackAsC (sx:<(sv:<(l,v)):>JObj) JObjV
+  jval v JInit sx          = dput JVal (sx:<v)
+  jval v s     sx          = derr JErr sx s
 
   %inline
   carr : StateAct q JState DSz
-  carr JArr (sv::st:>xs) = jval (JArray $ sv <>> []) st xs
-  carr s    x            = derr JErr s x
+  carr JArr (sx:>st:<sv) = jval (JArray $ sv <>> []) st sx
+  carr s    sx           = derr JErr sx s
 
   %inline
   cobj : StateAct q JState DSz
-  cobj JObj (sp::st:>xs) = jval (JObject $ sp <>> []) st xs
-  cobj s    x            = derr JErr s x
+  cobj JObj (sx:>st:<sp) = jval (JObject $ sp <>> []) st sx
+  cobj s    sx           = derr JErr sx s
 
   %inline
   endstr : String -> StateAct q JState DSz
-  endstr s JObj x = dput JObjL (s::x)
-  endstr s st   x = jval (JString s) st x
+  endstr s JObj sx = dput JObjL (sx:<s)
+  endstr s st   sx = jval (JString s) st sx
 
   %inline
-  opn : JState [SnocList a] -> F1 q (Index DSz)
-  opn s = read1 sk.stack_ >>= \x => dput s ([<]::x)
+  opn : JState [<SnocList a] -> F1 q (Index DSz)
+  opn s = read1 sk.stack_ >>= \sx => dput s (sx:<[<])
 
 --------------------------------------------------------------------------------
 -- Lexers
@@ -169,12 +169,12 @@ jsonErr =
 jsonEOI : Index DSz -> DSK q -> F1 q (Either (BoundedErr Void) JSON)
 jsonEOI st sk =
   read1 sk.stack_ >>= \case
-    JVal:>v::_ => pure (Right v)
+    _:<v:>JVal => pure (Right v)
     _          => arrFail DSK jsonErr st sk
 
 public export
 djson : P1 q (BoundedErr Void) JSON
-djson = P (cast JInit) (init $ JInit:>[]) jsonTrans (\x => (Nothing #)) jsonErr jsonEOI
+djson = P (cast JInit) (init $ [<]:>JInit) jsonTrans (\x => (Nothing #)) jsonErr jsonEOI
 
 export %inline
 dparseJSON : Origin -> String -> Either (ParseError Void) JSON
@@ -183,51 +183,6 @@ dparseJSON = parseString djson
 export
 testDJSON : String -> IO ()
 testDJSON = either (putStrLn . interpolate) printLn . dparseJSON Virtual
-
---------------------------------------------------------------------------------
--- Streaming
---------------------------------------------------------------------------------
---
--- extract : Part -> (Part, Maybe $ List JSON)
--- extract (PF (JArray vs)) = (PF (JArray []), Just vs)
--- extract (PA PI sv)       = (PA PI [<], maybeList sv)
--- extract (PV sv)          = (PV [<], maybeList sv)
--- extract (PA p sv)        = let (p2,m) := extract p in (PA p2 sv, m)
--- extract (PO p sv)        = let (p2,m) := extract p in (PO p2 sv, m)
--- extract (PL p sv l)      = let (p2,m) := extract p in (PL p2 sv l, m)
--- extract p                = (p, Nothing)
---
--- arrChunk : DSK q -> F1 q (Maybe $ List JSON)
--- arrChunk sk = T1.do
---   p <- getStack
---   let (p2,res) := extract p
---   putStackAs p2 res
---
--- arrEOI : JST -> DSK q -> F1 q (Either (BoundedErr Void) (List JSON))
--- arrEOI st sk t =
---   case st == JIni of
---     True  => case getStack t of
---       PV sv # t => Right (sv <>> []) # t
---       _     # t => Right [] # t
---     False => case jsonEOI st sk t of
---       Right (JArray vs) # t => Right vs # t
---       Right _           # t => Right [] # t
---       Left x            # t => Left x # t
---
--- ||| A parser that is capable of streaming a single large
--- ||| array of JSON values.
--- export
--- jsonArray : P1 q (BoundedErr Void) JSz DSK (List JSON)
--- jsonArray = P JIni (init PI) jsonTrans arrChunk jsonErr arrEOI
---
--- ||| Parser that is capable of streaming large amounts of
--- ||| JSON values.
--- |||
--- ||| Values need not be separated by whitespace but the longest
--- ||| possible value will always be consumed.
--- export
--- jsonValues : P1 q (BoundedErr Void) JSz DSK (List JSON)
--- jsonValues = P JIni (init $ PV [<]) jsonTrans arrChunk jsonErr arrEOI
 
 --------------------------------------------------------------------------------
 -- Proofs

--- a/src/Text/ILex/DStack.idr
+++ b/src/Text/ILex/DStack.idr
@@ -14,37 +14,37 @@ import Text.ILex.Parser
 --------------------------------------------------------------------------------
 
 export
-infixr 7 :>
+infixl 7 :>
 
 public export
-data Stack : Bool -> (s : List Type -> Type) -> List Type -> Type where
-  Nil  : Stack False s []
-  (:>) : (st : s ts) -> Stack b s ts -> Stack True s []
-  (::) : (v : t)     -> Stack b s ts -> Stack False s (t::ts)
+data Stack : Bool -> (s : SnocList Type -> Type) -> SnocList Type -> Type where
+  Lin  : Stack False s [<]
+  (:>) : Stack b s ts -> (st : s ts) -> Stack True s [<]
+  (:<) : Stack b s ts -> (v : t) -> Stack False s (ts:<t)
 
 public export %inline
-push : {0 s : _} -> s [t] -> (v : t) -> Stack b s [] -> Stack True s []
-push st v stck = st :> v :: stck
+push : {0 s : _} -> Stack b s [<] -> (v : t) -> s [<t] -> Stack True s [<]
+push stck v st = stck :< v :> st
 
 --------------------------------------------------------------------------------
 -- Mutable, Dependent Parser State
 --------------------------------------------------------------------------------
 
 public export
-record DStack (s : List Type -> Type) (e : Type) (q : Type) where
+record DStack (s : SnocList Type -> Type) (e : Type) (q : Type) where
   [search q]
   constructor S
   line_      : Ref q Nat
   col_       : Ref q Nat
   positions_ : Ref q (SnocList Position)
   strings_   : Ref q (SnocList String)
-  stack_     : Ref q (Stack True s [])
+  stack_     : Ref q (Stack True s [<])
   error_     : Ref q (Maybe $ BoundedErr e)
   bytes_     : Ref q ByteString
 
 ||| Initializes a new parser stack.
 export
-init : Stack True s [] -> F1 q (DStack s e q)
+init : Stack True s [<] -> F1 q (DStack s e q)
 init st = T1.do
   ln <- ref1 Z
   cl <- ref1 Z
@@ -56,7 +56,7 @@ init st = T1.do
   pure (S ln cl ps ss sk er bs)
 
 export %inline
-HasStack (DStack s e) (Stack True s []) where
+HasStack (DStack s e) (Stack True s [<]) where
   stack = stack_
 
 export %inline
@@ -78,7 +78,7 @@ HasStringLits (DStack s e) where
   strings = strings_
 
 public export
-0 StateAct : Type -> (s : List Type -> Type) -> Bits32 -> Type
+0 StateAct : Type -> (s : SnocList Type -> Type) -> Bits32 -> Type
 StateAct q s r =
      {0 b : _}
   -> {0 ts : _}
@@ -91,25 +91,25 @@ parameters {auto sk : DStack s e q}
   export %inline
   dact : StateAct q s r -> F1 q (Index r)
   dact f t =
-   let (st:>x) # t := read1 sk.stack_ t
+   let (x:>st) # t := read1 sk.stack_ t
     in f st x t
 
   export %inline
   dput : s ts -> Cast (s ts) a => Stack b s ts -> F1 q a
-  dput st x = writeAs sk.stack_ (st:>x) (cast st)
+  dput st x = writeAs sk.stack_ (x:>st) (cast st)
 
   export %inline
-  dpush0 : s [] -> Cast (s []) a => F1 q a
+  dpush0 : s [<] -> Cast (s [<]) a => F1 q a
   dpush0 st t =
    let stck # t := read1 sk.stack_ t
-    in writeAs sk.stack_ (st:>stck) (cast st) t
+    in writeAs sk.stack_ (stck:>st) (cast st) t
 
   export %inline
-  dpush : s [t] -> Cast (s [t]) a => t -> F1 q a
-  dpush st v t =
+  dpush : t -> s [<t] -> Cast (s [<t]) a => F1 q a
+  dpush v st t =
    let stck # t := read1 sk.stack_ t
-    in writeAs sk.stack_ (st:>v::stck) (cast st) t
+    in writeAs sk.stack_ (stck:<v:>st) (cast st) t
 
   export %inline
-  derr : s [] -> Cast (s []) a => s ts -> Stack b s ts -> F1 q a
-  derr err st x = writeAs sk.stack_ (err:>st:>x) (cast err)
+  derr : s [<] -> Cast (s [<]) a => Stack b s ts -> s ts -> F1 q a
+  derr err st x = writeAs sk.stack_ (st:>x:>err) (cast err)


### PR DESCRIPTION
I wrote a simple toy parser with an `if t1 then t2 else t3` construct, and `t1` and `t2` appeared on the list-based stack in reverse order: `t2::t1::rem`. This is rubbish and leads to unnecessary confusion. Using a `SnocList` makes much more sense.